### PR TITLE
Add exception handling and avoid parameter confusion

### DIFF
--- a/xvs.py
+++ b/xvs.py
@@ -1560,6 +1560,9 @@ def mwaa(clip, aa_y=True, aa_c=False, cs_h=0, cs_v=0, aa_cmask=True, kernel_y=2,
     Steal from other one's script. Most likely written by mawen1250.
     add opencl support for nnedi3,use znedi3 replace nnedi3
     """
+    if clip.format.bits_per_sample != 16:
+       raise vs.Error('mwaa: Only 16bit supported')
+
     ## internal functions
     mode="nnedi3cl" if opencl else "znedi3"
     def aa_kernel_vertical(clip):
@@ -1620,8 +1623,10 @@ def mwcfix(clip, kernel=1, restore=5, a=2, grad=2, warp=6, thresh=96, blur=3, re
     chroma restoration
     Steal from other one's script. Most likely written by mawen1250.
     repalce nnedi3 with znedi3
-
     """
+    if clip.format.bits_per_sample != 16:
+       raise vs.Error('mwcfix: Only 16bit supported')
+
     clip_y = mvf.GetPlane(clip, 0)
     clip_u = mvf.GetPlane(clip, 1)
     clip_v = mvf.GetPlane(clip, 2)

--- a/xvs.py
+++ b/xvs.py
@@ -1742,9 +1742,9 @@ def mwdbmask(clip, chroma=True, sigma=2.5, t_h=1.0, t_l=0.5, yuv444=None, cs_h=0
     if yuv444 is None:
         yuv444 = not yuv420
     ## Canny edge detector
-    emask = clip.tcanny.TCanny(sigma, t_h, t_l, planes=[0,1,2] if chroma else [0])
+    emask = clip.tcanny.TCanny(sigma=sigma, t_h=t_h, t_l=t_l, planes=[0,1,2] if chroma else [0])
     if lmask is not None:
-        emask2 = clip.tcanny.TCanny(sigma2, t_h2, t_l2, planes=[0,1,2] if chroma else [0])
+        emask2 = clip.tcanny.TCanny(sigma=sigma2, t_h=t_h2, t_l=t_l2, planes=[0,1,2] if chroma else [0])
         emask = core.std.MaskedMerge(emask, emask2, lmask, [0,1,2] if chroma else [0], True)
     ## apply morphologic filters and merge mask planes
     emaskY = mvf.GetPlane(emask, 0)


### PR DESCRIPTION
* https://github.com/xyx98/my-vapoursynth-script/commit/6e0feba60a517c5816fdd691d8c452cd610da924 : Add exception handling

  Avoid unclear error information in #1. In addition to #1, for 8bit input, `mwaa` will occurr this error.
  ```
  File "C:\Program Files\Python38\lib\site-packages\xvs.py", line 1605, in mwaa
  aa_merge = core.std.MaskedMerge(clip, aa, aamask, [0], False)
  File "src\cython\vapoursynth.pyx", line 1852, in vapoursynth.Function.__call__
  vapoursynth.Error: MaskedMerge: both clips must have constant format and dimensions, and the 
  same format and dimensions
  ```

  Obviously, the functions `mwaa` and `mwcfix` are only suitable for 16bit input, because them use `fmtc.resample`. For 32bit or 8bit input, converting depth inside these functions may be meaningless. So add exception handling is a simple and effective method.

* https://github.com/xyx98/my-vapoursynth-script/commit/4813e7b9d7bedf08d3d584c929c41c12a2aeb431: Avoid parameter confusion

  `tcanny.TCanny` has a parameter `sigma_v` between `sigma` and `t_h`, which may result this error in `mwdbmask`:

  **script**:
  ```python
  res = xvs.mwdbmask(src)
  ```

  **related code in `mwdbmask`**:
  https://github.com/xyx98/my-vapoursynth-script/blob/75877c86aab2218ae30a880183e45d2e4135c306/xvs.py#L1740-L1742

  **error info**:
  ```
  File "C:\Program Files\Python38\lib\site-packages\xvs.py", line 1742, in mwdbmask
  emask = clip.tcanny.TCanny(sigma, t_h, t_l, planes=[0,1,2] if chroma else [0])
  File "src\cython\vapoursynth.pyx", line 1852, in vapoursynth.Function.__call__
  vapoursynth.Error: TCanny: t_h must be greater than t_l
  ```